### PR TITLE
Fixed SDTID Null Reference in Local Thorough Scans

### DIFF
--- a/SessionGopher.ps1
+++ b/SessionGopher.ps1
@@ -332,6 +332,7 @@ function Invoke-SessionGopher {
       $ArrayOfRDPSessions = New-Object System.Collections.ArrayList
       $ArrayOfRDPFiles = New-Object System.Collections.ArrayList
       $ArrayOfFileZillaSessions = New-Object System.Collections.ArrayList
+      $ArrayOfSDTIDFiles = New-Object System.Collections.ArrayList
 
       $objUser = (GetMappedSID)
       $Source = (Hostname) + "\" + (Split-Path $objUser.Value -Leaf)


### PR DESCRIPTION
`ArrayOfSDTIDFiles` is never instantiated in the local-only code path, causing the following error if the script is run locally with `-thorough` and it finds an `.sdtid` file on the filesystem:

![image](https://github.com/user-attachments/assets/291c2956-023c-46b7-a53e-740c02adf5ad)

Adding this line fixes the issue and `.sdtid` files are properly enumerated:

![image](https://github.com/user-attachments/assets/203506ae-7a11-450f-94f0-c36a1b2e247c)

Thank you!